### PR TITLE
feat: add network config, fix streaming, restrict file inlining

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -264,11 +264,11 @@ gemini-api files download env_xyz789 --dry-run
 
 ```
 my-agent/
-├── agent.yaml       # Configuration
-├── AGENTS.md        # System instructions (uploaded to environment)
+├── agent.yaml       # Configuration (not inlined)
+├── AGENTS.md        # System instructions (inlined to /.agents/AGENTS.md)
 ├── .env             # Credentials (inlined to /credentials/.env)
-├── skills/          # Custom skills
-└── workspace/       # Files seeded into remote environment
+├── skills/          # Custom skills (all files inlined recursively)
+└── workspace/       # Files seeded into remote environment (all files inlined recursively)
 ```
 
 ### `agent.yaml`
@@ -288,8 +288,7 @@ tools:
   - type: google_search
 
 # Environment
-environment:
-  enabled: true
+environment: remote
 
 # OR derive from existing environment
 # base_environment: env_abc123
@@ -315,6 +314,8 @@ Files seeded into the remote environment at `/.agents/workspace/`. All files in 
 | Binary files | Base64-encoded with `"encoding": "base64"` | `.pdf`, `.png`, `.jpg`, `.mp3`, `.wav`, `.zip` |
 | Files > 1 MB | Skipped | — |
 
+> **Note:** Only `AGENTS.md`, `.env`, `workspace/`, and `skills/` are inlined from the agent directory. All other root-level files and directories are ignored.
+
 Binary files are automatically detected by extension. The following are treated as binary:
 - Images: `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.bmp`, `.tiff`, `.heic`, `.heif`
 - Audio: `.wav`, `.mp3`, `.aac`, `.ogg`, `.flac`, `.opus`, `.m4a`
@@ -328,14 +329,13 @@ Controls the sandbox environment for the agent:
 
 ```yaml
 # Enable a managed sandbox environment
-environment:
-  enabled: true
+environment: remote
 
 # OR reuse an existing environment by ID
 # base_environment: env_abc123
 ```
 
-When `environment.enabled` is `true`, the API provisions a sandbox with code execution capabilities. Workspace files, skills, and credentials are seeded into it before the agent runs.
+When `environment` is `"remote"`, the API provisions a sandbox with code execution capabilities. Workspace files, skills, and credentials are seeded into it before the agent runs.
 
 ---
 

--- a/skills/gemini-api-cli/references/agents.md
+++ b/skills/gemini-api-cli/references/agents.md
@@ -16,12 +16,14 @@ This creates a directory with the default structure.
 
 ```
 my-agent/
-├── agent.yaml       # Configuration (ID, tools, etc.)
-├── AGENTS.md        # System instructions (uploaded to environment)
+├── agent.yaml       # Configuration (ID, tools, etc.) — not inlined
+├── AGENTS.md        # System instructions (inlined to /.agents/AGENTS.md)
 ├── .env             # Credentials (inlined to /credentials/.env)
-├── skills/          # Custom skills (add your custom skills here)
-└── workspace/       # Files seeded into remote environment
+├── skills/          # Custom skills (all files inlined recursively)
+└── workspace/       # Files seeded into remote environment (all files inlined recursively)
 ```
+
+> **Note:** Only `AGENTS.md`, `.env`, `workspace/`, and `skills/` are inlined from the agent directory. All other root-level files and directories (e.g., `README.md`, `package.json`) are ignored during `agents test` and `agents create`.
 
 ### Adding Skills
 
@@ -37,7 +39,7 @@ Optional fields:
 - `description`: Description of the agent
 - `system_instruction`: Short system instruction (prefer `AGENTS.md` for long instructions)
 - `tools`: List of tools (e.g., `code_execution`, `google_search`)
-- `environment`: `enabled: true` or `base_environment: <env_id>`
+- `environment`: `"remote"` or `base_environment: <env_id>`
 
 ## Testing an Agent Locally
 

--- a/src/commands/agents/create.ts
+++ b/src/commands/agents/create.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from "citty";
-import { apiRequest, resolveContext, type Source } from "../../lib/api";
+import { apiRequest, resolveContext, type Source, normalizeSources, validateSources } from "../../lib/api";
 import { loadAgent } from "../../lib/config";
 import { CLIError, ConfigError } from "../../lib/errors";
 import { collectInlineFiles, getEnvKeys } from "../../lib/files";
@@ -57,8 +57,17 @@ Examples:
       if (baseEnvOverride) {
         body.base_environment = baseEnvOverride;
       } else if (config.base_environment) {
-        // base_environment mode: skip file inlining, use the env_id directly
-        body.base_environment = config.base_environment;
+        if (typeof config.base_environment === "string") {
+          body.base_environment = config.base_environment;
+        } else if (typeof config.base_environment === "object") {
+          const baseEnvObj = config.base_environment as any;
+          if (baseEnvObj.sources) {
+            const normalizedBaseSources = normalizeSources(baseEnvObj.sources);
+            validateSources(normalizedBaseSources);
+            baseEnvObj.sources = normalizedBaseSources;
+          }
+          body.base_environment = baseEnvObj;
+        }
       } else {
         // Collect and inline files from the agent directory
         const inlineFiles = await collectInlineFiles(agentDir);
@@ -74,10 +83,13 @@ Examples:
           sources.push(...(env.sources as Source[]));
         }
 
-        if (sources.length > 0) {
+        const normalized = normalizeSources(sources);
+        validateSources(normalized);
+
+        if (normalized && normalized.length > 0) {
           body.base_environment = {
             type: "remote",
-            sources: sources,
+            sources: normalized,
           };
         }
 

--- a/src/commands/agents/init.ts
+++ b/src/commands/agents/init.ts
@@ -101,7 +101,7 @@ Examples:
       base_agent: baseAgent,
       description: `Scaffolded agent ${name}`,
       tools: [{ type: "code_execution" }],
-      environment: { enabled: true },
+      environment: "remote",
     };
 
     fs.writeFileSync(path.join(name, "agent.yaml"), yaml.dump(agentConfig), "utf-8");

--- a/src/commands/agents/list.ts
+++ b/src/commands/agents/list.ts
@@ -34,7 +34,7 @@ Examples:
   async run({ args }) {
     try {
       const ctx = resolveContext(args);
-      const url = "/agents";
+      const url = "/agents?pageSize=100";
 
       if (args["dry-run"]) {
         printCurl("GET", `${ctx.baseUrl}${url}`, ctx.apiKey);

--- a/src/commands/agents/test.ts
+++ b/src/commands/agents/test.ts
@@ -20,6 +20,8 @@ import {
   type RunOptions,
   resolveContext,
   type Source,
+  normalizeSources,
+  validateSources,
 } from "../../lib/api";
 import { loadAgent } from "../../lib/config";
 import { CLIError, ConfigError } from "../../lib/errors";
@@ -27,9 +29,11 @@ import { collectInlineFiles, getEnvKeys } from "../../lib/files";
 import { logRequest, logResponse } from "../../lib/logger";
 import {
   HumanStreamRenderer,
+  mapContentToStepEvent,
   printCompletionSummary,
   printCurl,
   printError,
+  renderStepEvent,
 } from "../../lib/output";
 import { globalFlags } from "../../lib/shared-args";
 import { processStream } from "../../lib/stream";
@@ -101,9 +105,9 @@ Examples:
       }
 
       // Build environment config
-      let environment: Record<string, unknown> = {};
+      let environment: any;
       if (args.environment) {
-        environment = { env_id: args.environment };
+        environment = args.environment;
       } else {
         const sources: Source[] = [...inlineFiles] as unknown as Source[];
         if (config.sources) {
@@ -116,11 +120,23 @@ Examples:
           sources.push(...(env.sources as Source[]));
         }
 
-        if (sources.length > 0) {
-          environment = { type: "remote", sources: sources };
+        const normalized = normalizeSources(sources);
+        validateSources(normalized);
+
+        if (normalized && normalized.length > 0) {
+          environment = { type: "remote", sources: normalized };
         } else if (config.environment) {
-          // Use environment from agent.yaml (e.g. { enabled: true })
-          environment = config.environment;
+          if (typeof config.environment === "string") {
+            environment = config.environment;
+          } else if (typeof config.environment === "object") {
+            const envObj = config.environment as any;
+            if (envObj.sources) {
+              const normalizedEnvSources = normalizeSources(envObj.sources);
+              validateSources(normalizedEnvSources);
+              envObj.sources = normalizedEnvSources;
+            }
+            environment = envObj;
+          }
         }
       }
 
@@ -136,7 +152,7 @@ Examples:
         tools: config.tools as any,
         previousInteractionId: args["previous-interaction-id"] as string | undefined,
         stream: true,
-        environment: Object.keys(environment).length > 0 ? environment : undefined,
+        environment: environment || undefined,
       };
 
       const body = buildInteractionRequest(runOpts);
@@ -159,18 +175,11 @@ Examples:
         });
       } else {
         const renderer = new HumanStreamRenderer();
-        const activeBlocks = new Map<number, string>();
 
         await processStream(response, {
           onEvent: (event, block) => {
-            if (event.type === "step.start" || event.type === "step.stop") {
-              renderer.handleStepEvent(event);
-            } else if (event.type === "content.start") {
-              activeBlocks.set(event.data.index, event.data.content.type);
-            } else if (event.type === "content.delta") {
-              const type = activeBlocks.get(event.data.index) || "text";
-              renderer.handleEvent(event, type, block);
-            }
+            const mapped = mapContentToStepEvent(event);
+            renderStepEvent(renderer, mapped, block);
           },
           onComplete: (result) => {
             renderer.finish();

--- a/src/commands/agents/update.ts
+++ b/src/commands/agents/update.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { defineCommand } from "citty";
-import { apiRequest, resolveContext, type Source } from "../../lib/api";
+import { apiRequest, resolveContext, type Source, normalizeSources, validateSources } from "../../lib/api";
 import { loadAgent } from "../../lib/config";
 import { CLIError, ConfigError } from "../../lib/errors";
 import { collectInlineFiles, getEnvKeys } from "../../lib/files";
@@ -62,7 +62,17 @@ Examples:
 
       // Handle base_environment
       if (config.base_environment) {
-        body.base_environment = config.base_environment;
+        if (typeof config.base_environment === "string") {
+          body.base_environment = config.base_environment;
+        } else if (typeof config.base_environment === "object") {
+          const baseEnvObj = config.base_environment as any;
+          if (baseEnvObj.sources) {
+            const normalizedBaseSources = normalizeSources(baseEnvObj.sources);
+            validateSources(normalizedBaseSources);
+            baseEnvObj.sources = normalizedBaseSources;
+          }
+          body.base_environment = baseEnvObj;
+        }
       } else {
         // Collect and inline files from the agent directory
         const inlineFiles = await collectInlineFiles(agentDir);
@@ -78,10 +88,13 @@ Examples:
           sources.push(...(env.sources as Source[]));
         }
 
-        if (sources.length > 0) {
+        const normalized = normalizeSources(sources);
+        validateSources(normalized);
+
+        if (normalized && normalized.length > 0) {
           body.base_environment = {
             type: "remote",
-            sources: sources,
+            sources: normalized,
           };
         }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -33,10 +33,12 @@ import { inputToContentBlock, saveMediaOutputs } from "../lib/files";
 import { logRequest, logResponse } from "../lib/logger";
 import {
   HumanStreamRenderer,
+  mapContentToStepEvent,
   printCompletionSummary,
   printCurl,
   printError,
   printPollingStatus,
+  renderStepEvent,
 } from "../lib/output";
 import { globalFlags } from "../lib/shared-args";
 import type { StreamResult } from "../lib/stream";
@@ -88,6 +90,14 @@ Examples:
     environment: {
       type: "string",
       description: "Environment to use ('remote' or a specific env_id)",
+    },
+    network: {
+      type: "string",
+      description: "Disable network access ('disabled')",
+    },
+    "network-allowlist": {
+      type: "string",
+      description: "Comma-separated domain allowlist for network egress",
     },
     input: {
       type: "string",
@@ -269,11 +279,20 @@ Examples:
 
     let environment: any;
     if (args.environment) {
-      if (args.environment === "remote") {
-        environment = { enabled: true };
-      } else {
-        environment = { env_id: args.environment };
+      environment = args.environment;
+    }
+
+    if (args.network || args["network-allowlist"]) {
+      const envObj: any = { type: "remote" };
+      if (args.network === "disabled") {
+        envObj.network = "disabled";
+      } else if (args["network-allowlist"]) {
+        const domains = (args["network-allowlist"] as string).split(",").map((d) => d.trim());
+        envObj.network = {
+          allowlist: domains.map((domain) => ({ domain })),
+        };
       }
+      environment = envObj;
     }
 
     const runOpts: RunOptions = {
@@ -332,29 +351,11 @@ Examples:
       });
     } else {
       const renderer = new HumanStreamRenderer();
-      const activeBlocks = new Map<number, string>();
-      const activeSteps = new Map<number, string>();
 
       await processStream(response, {
         onEvent: (event, block) => {
-          if (event.type === "step.start" || event.type === "step.stop") {
-            renderer.handleStepEvent(event);
-            if (event.type === "step.start") {
-              const index = event.data.index ?? event.data.step_index;
-              if (index !== undefined) {
-                activeSteps.set(index, event.data.step?.type || "text");
-              }
-            }
-          } else if (event.type === "step.delta") {
-            const index = event.data.index ?? event.data.step_index;
-            const type = activeSteps.get(index) || "text";
-            renderer.handleEvent(event, type, block);
-          } else if (event.type === "content.start") {
-            activeBlocks.set(event.data.index, event.data.content.type);
-          } else if (event.type === "content.delta") {
-            const type = activeBlocks.get(event.data.index) || "text";
-            renderer.handleEvent(event, type, block);
-          }
+          const mapped = mapContentToStepEvent(event);
+          renderStepEvent(renderer, mapped, block);
         },
         onComplete: (result) => {
           renderer.finish();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -267,6 +267,27 @@ export interface Source {
   [key: string]: string;
 }
 
+export function normalizeSource(source: Source): Source {
+  if (source.type === "github") {
+    return { ...source, type: "repository" };
+  }
+  return source;
+}
+
+export function normalizeSources(sources?: Source[]): Source[] | undefined {
+  if (!sources) return undefined;
+  return sources.map(normalizeSource);
+}
+
+export function validateSources(sources?: Source[]): void {
+  if (!sources) return;
+  for (const source of sources) {
+    if (source.target === "/") {
+      throw new CLIError('Invalid source target: "/". Custom sources cannot be mounted at root.');
+    }
+  }
+}
+
 export function parseSourceFlag(value: string): Source {
   // inline:<target>:<content>
   if (value.startsWith("inline:")) {
@@ -288,6 +309,16 @@ export function parseSourceFlag(value: string): Source {
     return { type: "github", source: rest.substring(0, idx), target: rest.substring(idx + 1) };
   }
 
+  // repository:<url>:<target> — split on last colon since URLs contain colons
+  if (value.startsWith("repository:")) {
+    const rest = value.substring(11);
+    const idx = rest.lastIndexOf(":");
+    if (idx === -1) {
+      throw new CLIError("Invalid repository source format. Expected: repository:<url>:<target>");
+    }
+    return { type: "repository", source: rest.substring(0, idx), target: rest.substring(idx + 1) };
+  }
+
   // gcs:<source>:<target> — split on last colon
   if (value.startsWith("gcs:")) {
     const rest = value.substring(4);
@@ -298,7 +329,7 @@ export function parseSourceFlag(value: string): Source {
     return { type: "gcs", source: rest.substring(0, idx), target: rest.substring(idx + 1) };
   }
 
-  throw new CLIError(`Unknown source type in '${value}'\n\n  Available: inline, github, gcs`);
+  throw new CLIError(`Unknown source type in '${value}'\n\n  Available: inline, github, repository, gcs`);
 }
 
 export interface RunOptions {
@@ -324,7 +355,7 @@ export interface RunOptions {
 
   sources?: Source[];
   // Environment override (for agents test)
-  environment?: object;
+  environment?: string | object;
 }
 
 // Agents that automatically get `environment: { enabled: true }` when used
@@ -354,11 +385,26 @@ export function buildInteractionRequest(opts: RunOptions): object {
     input: opts.input,
   };
 
-  // Environment: custom sources take priority over auto-enable
-  if (opts.sources && opts.sources.length > 0) {
-    body.environment = { type: "remote", sources: opts.sources };
+  // Normalize and validate sources
+  const normalizedSources = normalizeSources(opts.sources);
+  validateSources(normalizedSources);
+
+  if (normalizedSources && normalizedSources.length > 0) {
+    body.environment = { type: "remote", sources: normalizedSources };
+  } else if (opts.environment) {
+    if (typeof opts.environment === "string") {
+      body.environment = opts.environment;
+    } else if (typeof opts.environment === "object") {
+      const envObj = opts.environment as any;
+      if (envObj.sources) {
+        const envSources = normalizeSources(envObj.sources);
+        validateSources(envSources);
+        envObj.sources = envSources;
+      }
+      body.environment = envObj;
+    }
   } else if (opts.agent && !isDeepResearchAgent(opts.agent)) {
-    body.environment = { enabled: true };
+    body.environment = "remote";
   }
 
   if (opts.model) body.model = opts.model;
@@ -380,9 +426,6 @@ export function buildInteractionRequest(opts: RunOptions): object {
       thinking_summaries: "auto",
     };
   }
-
-  // Environment override (from agents test command)
-  if (opts.environment) body.environment = opts.environment;
 
   // Generation Config
   const generationConfig: any = {};

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -224,6 +224,12 @@ export async function collectInlineFiles(
       const fullPath = join(currentDir, entry.name);
 
       if (entry.isDirectory()) {
+        // Only walk into 'workspace' and 'skills' from the root directory
+        if (currentDir === dir) {
+          if (entry.name !== "workspace" && entry.name !== "skills") {
+            continue;
+          }
+        }
         if (entry.name === "node_modules" || entry.name === ".git" || entry.name === ".gemini")
           continue;
         await walk(fullPath);
@@ -242,6 +248,13 @@ export async function collectInlineFiles(
             // Ignore
           }
           continue;
+        }
+
+        // If we are in the root directory, only allow AGENTS.md
+        if (currentDir === dir) {
+          if (rel !== "AGENTS.md") {
+            continue;
+          }
         }
 
         const info = await stat(fullPath);

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -34,16 +34,20 @@ export function printCurl(method: string, url: string, apiKey: string, body?: un
 }
 
 export class HumanStreamRenderer {
-  private currentBlockIndex: number | null = null;
+  private currentStepIndex: number | null = null;
+  private currentStepType: string | null = null;
+  private currentStepName: string | null = null;
   private prefixPrinted = false;
+  private accumulatedArguments = "";
+  private accumulatedResult = "";
   private colWidth = 15;
-  private wasFunctionCall = false;
 
   constructor(private stdout: typeof process.stdout = process.stdout) {}
 
   private getPrefix(type: string): string {
     const prefixes: Record<string, string> = {
       text: "[text]",
+      thought: "[thought]",
       thought_summary: "[thought]",
       function_call: "[tool]",
       function_result: "[result]",
@@ -67,73 +71,94 @@ export class HumanStreamRenderer {
     return type in prefixes ? prefixes[type] : `[${type}]`;
   }
 
-  handleStepEvent(event: StreamEvent) {
-    if (event.type === "step.start") {
-      const stepType = event.data.step?.type || "unknown";
-      this.stdout.write(`${"[step]".padEnd(this.colWidth)}▸ ${stepType} started\n`);
+  handleStepStart(event: StreamEvent, block?: ContentBlock) {
+    const index = event.data.index ?? event.data.step_index;
+    if (index === undefined) return;
 
-      // Print content if available in step.start (e.g. for short responses)
-      if (event.data.step?.type === "model_output" && Array.isArray(event.data.step.content)) {
+    // Finalize previous step if index changed
+    if (this.currentStepIndex !== null && this.currentStepIndex !== index) {
+      this.finalizeStep();
+    }
+
+    this.currentStepIndex = index;
+    this.currentStepType = event.data.step?.type || "unknown";
+    this.currentStepName = event.data.step?.name || null;
+    this.prefixPrinted = false;
+    this.accumulatedArguments = "";
+    this.accumulatedResult = "";
+
+    if (this.currentStepType === "thought") {
+      const prefix = this.getPrefix("thought").padEnd(this.colWidth);
+      this.stdout.write(`${prefix}▸ thinking\n`);
+      this.prefixPrinted = true;
+    } else if (this.currentStepType === "model_output") {
+      if (Array.isArray(event.data.step?.content)) {
         for (const c of event.data.step.content) {
           if (c.type === "text" && c.text) {
-            this.stdout.write(`${"[text]".padEnd(this.colWidth)}${c.text}\n`);
+            const prefix = this.getPrefix("text").padEnd(this.colWidth);
+            this.stdout.write(`${prefix}${c.text}`);
+            this.prefixPrinted = true;
           }
         }
       }
-
-      if (event.data.step?.type === "code_execution_result" && event.data.step.result) {
-        this.stdout.write(`${"[result]".padEnd(this.colWidth)}${event.data.step.result}\n`);
-      }
-    } else if (event.type === "step.stop") {
-      const stepType = event.data.step?.type || "unknown";
-      const status = event.data.step?.status || "completed";
-      this.stdout.write(`${"[step]".padEnd(this.colWidth)}▪ ${stepType} ${status}\n`);
     }
   }
 
-  handleEvent(event: StreamEvent, type: string, block?: ContentBlock) {
-    if (event.type !== "content.delta" && event.type !== "step.delta") return;
-    if (type === "thought" || type === "thought_summary" || type === "thought_signature") return;
-
+  handleStepDelta(event: StreamEvent, block?: ContentBlock) {
     const index = event.data.index ?? event.data.step_index;
-    const delta = event.data.delta;
+    if (index === undefined || this.currentStepIndex !== index) return;
 
-    if (this.currentBlockIndex !== index) {
-      if (this.currentBlockIndex !== null) {
-        if (this.wasFunctionCall) {
-          this.stdout.write(")");
-        }
-        this.stdout.write("\n");
-      }
-      this.currentBlockIndex = index;
-      this.prefixPrinted = false;
-      this.wasFunctionCall = false;
+    const delta = event.data.delta;
+    if (!delta) return;
+
+    const type = this.currentStepType || "text";
+
+    if (type === "thought" || type === "thought_summary" || type === "thought_signature") {
+      return;
     }
 
-    const prefix = this.getPrefix(type);
-    let content = "";
+    if (type === "function_call" || type === "code_execution_call") {
+      if (delta.arguments) {
+        this.accumulatedArguments += typeof delta.arguments === "string"
+          ? delta.arguments
+          : JSON.stringify(delta.arguments);
+      }
+      if (delta.name) {
+        this.currentStepName = delta.name;
+      }
+      return;
+    }
 
-    if (delta.text) content = delta.text;
-    else if (delta.arguments)
-      content =
-        typeof delta.arguments === "string" ? delta.arguments : JSON.stringify(delta.arguments);
-    else if (delta.code) content = delta.code;
-    else if (delta.result)
-      content = typeof delta.result === "string" ? delta.result : JSON.stringify(delta.result);
-    else if (delta.query) content = delta.query;
-    else if (delta.url) content = delta.url;
-    else if (delta.name) content = delta.name;
+    if (type === "function_result") {
+      if (delta.result) {
+        this.accumulatedResult += typeof delta.result === "string"
+          ? delta.result
+          : JSON.stringify(delta.result);
+      }
+      if (delta.name) {
+        this.currentStepName = delta.name;
+      }
+      return;
+    }
+
+    let content = "";
+    let prefixType = type;
+
+    if (type === "model_output") {
+      prefixType = "text";
+      if (delta.text) content = delta.text;
+    } else if (type === "code_execution_result") {
+      if (delta.result) content = delta.result;
+    } else {
+      if (delta.text) content = delta.text;
+      else if (delta.result) content = typeof delta.result === "string" ? delta.result : JSON.stringify(delta.result);
+    }
 
     if (content) {
+      const prefix = this.getPrefix(prefixType);
       if (prefix) {
         if (!this.prefixPrinted) {
           this.stdout.write(prefix.padEnd(this.colWidth));
-
-          if (block && (block as any).name) {
-            this.stdout.write(`${(block as any).name}(`);
-            this.wasFunctionCall = true;
-          }
-
           this.prefixPrinted = true;
         }
 
@@ -152,11 +177,130 @@ export class HumanStreamRenderer {
     }
   }
 
-  finish() {
-    if (this.wasFunctionCall) {
-      this.stdout.write(")");
+  handleStepStop(event: StreamEvent, block?: ContentBlock) {
+    const index = event.data.index ?? event.data.step_index;
+    if (index === undefined || this.currentStepIndex !== index) return;
+
+    this.finalizeStep();
+  }
+
+  private finalizeStep() {
+    if (this.currentStepIndex === null) return;
+
+    const type = this.currentStepType;
+    const name = this.currentStepName;
+
+    if (type === "thought") {
+      const prefix = this.getPrefix("thought").padEnd(this.colWidth);
+      this.stdout.write(`${prefix}▪ completed\n`);
+    } else if (type === "function_call") {
+      const prefix = this.getPrefix("function_call").padEnd(this.colWidth);
+      let argsObj: any = {};
+      try {
+        argsObj = JSON.parse(this.accumulatedArguments);
+      } catch {
+        argsObj = { raw: this.accumulatedArguments };
+      }
+
+      if (name === "write_file") {
+        const path = argsObj.path || "unknown";
+        this.stdout.write(`${prefix}${name}(path="${path}", content=<...>)` + "\n");
+      } else {
+        const argsStr = JSON.stringify(argsObj);
+        const truncatedArgs = argsStr.length > 100 ? argsStr.substring(0, 100) + "..." : argsStr;
+        this.stdout.write(`${prefix}${name || "unknown"}(${truncatedArgs})` + "\n");
+      }
+    } else if (type === "function_result") {
+      const prefix = this.getPrefix("function_result").padEnd(this.colWidth);
+      let resultObj: any = {};
+      try {
+        resultObj = JSON.parse(this.accumulatedResult);
+      } catch {
+        resultObj = this.accumulatedResult;
+      }
+
+      const resultStr = typeof resultObj === "string" ? resultObj : JSON.stringify(resultObj);
+      const truncatedResult = resultStr.length > 100 ? resultStr.substring(0, 100) + "..." : resultStr;
+      this.stdout.write(`${prefix}${name || "tool"}: ${truncatedResult}\n`);
+    } else if (type === "code_execution_call") {
+      const prefix = this.getPrefix("code_execution_call").padEnd(this.colWidth);
+      let argsObj: any = {};
+      try {
+        argsObj = JSON.parse(this.accumulatedArguments);
+      } catch {
+        argsObj = { code: this.accumulatedArguments };
+      }
+      const code = argsObj.code || argsObj.raw || "";
+      this.stdout.write(`${prefix}${code}\n`);
+    } else if (type === "model_output" || type === "code_execution_result") {
+      if (this.prefixPrinted) {
+        this.stdout.write("\n");
+      }
     }
-    this.stdout.write("\n");
+
+    this.currentStepIndex = null;
+    this.currentStepType = null;
+    this.currentStepName = null;
+    this.prefixPrinted = false;
+    this.accumulatedArguments = "";
+    this.accumulatedResult = "";
+  }
+
+  finish() {
+    this.finalizeStep();
+  }
+}
+
+/**
+ * Maps content.* SSE events to step.* events for the renderer.
+ * Some API endpoints still emit content.start/delta/stop; this function
+ * normalises them so the renderer only needs to handle step.* events.
+ */
+export function mapContentToStepEvent(event: StreamEvent): StreamEvent {
+  if (event.type === "content.start") {
+    return {
+      type: "step.start",
+      data: {
+        index: event.data.index,
+        step: { type: event.data.content?.type || "text", status: "in_progress" },
+      },
+      raw: event.raw,
+    };
+  }
+  if (event.type === "content.delta") {
+    return {
+      type: "step.delta",
+      data: {
+        index: event.data.index,
+        delta: event.data.delta,
+      },
+      raw: event.raw,
+    };
+  }
+  if (event.type === "content.stop") {
+    return {
+      type: "step.stop",
+      data: {
+        index: event.data.index,
+      },
+      raw: event.raw,
+    };
+  }
+  return event;
+}
+
+/** Dispatch a (possibly mapped) step event to the renderer. */
+export function renderStepEvent(
+  renderer: HumanStreamRenderer,
+  event: StreamEvent,
+  block?: ContentBlock,
+): void {
+  if (event.type === "step.start") {
+    renderer.handleStepStart(event, block);
+  } else if (event.type === "step.delta") {
+    renderer.handleStepDelta(event, block);
+  } else if (event.type === "step.stop") {
+    renderer.handleStepStop(event, block);
   }
 }
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -36,21 +36,34 @@ const SourceSchema = z.discriminatedUnion("type", [
     source: z.string(),
     target: z.string(),
   }),
+  z.object({
+    type: z.literal("repository"),
+    source: z.string(),
+    target: z.string(),
+  }),
 ]);
 
-const ConfigSchema = z.object({
-  sources: z.array(SourceSchema),
+
+const NetworkRuleSchema = z.object({
+  domain: z.string(),
+  transform: z.record(z.string()).optional(),
 });
+
+const NetworkConfigSchema = z.union([
+  z.literal("disabled"),
+  z.object({
+    allowlist: z.array(NetworkRuleSchema),
+  }),
+]);
 
 const RemoteEnvironmentSchema = z.object({
   type: z.literal("remote"),
-  sources: z.array(SourceSchema),
+  sources: z.array(SourceSchema).optional(),
+  network: NetworkConfigSchema.optional(),
 });
 
 export const EnvironmentSchema = z.union([
-  z.object({ enabled: z.boolean() }),
-  z.object({ env_id: z.string() }),
-  z.object({ config: ConfigSchema }),
+  z.string(), // Supports "remote" or "env_xyz"
   RemoteEnvironmentSchema,
 ]);
 
@@ -67,7 +80,7 @@ export const AgentConfigSchema = z
     instructions: z.string().optional(),
     tools: z.array(ToolSchema).optional(),
     base_environment: z
-      .union([z.string(), z.object({ config: ConfigSchema }), RemoteEnvironmentSchema])
+      .union([z.string(), RemoteEnvironmentSchema])
       .optional(),
     sources: z.array(SourceSchema).optional(),
     environment: EnvironmentSchema.optional(),

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -371,12 +371,74 @@ function handleEvent(
         if (delta.type) step.type = delta.type;
         if (delta.status) step.status = delta.status;
 
-        // Also append media data to contentBlocks if available
-        const block = contentBlocks.get(index);
+        // Also append media/block data to contentBlocks if available
+        let block = contentBlocks.get(index);
+        if (!block && delta.type) {
+          let type: string | undefined;
+          if ([
+            "text",
+            "image",
+            "audio",
+            "video",
+            "document",
+            "function_call",
+            "code_execution_call",
+            "code_execution_result",
+            "thought_summary",
+            "thought_signature",
+            "url_context_call",
+            "google_search_call",
+            "mcp_server_tool_call",
+            "file_search_call",
+            "google_maps_call",
+            "function_result",
+            "url_context_result",
+            "google_search_result",
+            "mcp_server_tool_result",
+            "file_search_result",
+            "google_maps_result",
+            "text_annotation"
+          ].includes(delta.type)) {
+            type = delta.type;
+          } else if (delta.type === "thought") {
+            type = "thought_summary";
+          }
+
+          if (type) {
+            block = { type } as any;
+            contentBlocks.set(index, block);
+          }
+        }
+
         if (block) {
           if (delta.data) (block as any).data = ((block as any).data || "") + delta.data;
           if (delta.mime_type) (block as any).mimeType = delta.mime_type;
           if (delta.text) (block as any).text = ((block as any).text || "") + delta.text;
+          if (delta.signature) (block as any).signature = delta.signature;
+
+          // Tool call arguments
+          if (delta.name) (block as any).name = delta.name;
+          if (delta.arguments) {
+            if (typeof delta.arguments === "string") {
+              (block as any).arguments = ((block as any).arguments || "") + delta.arguments;
+            } else {
+              (block as any).arguments = delta.arguments;
+            }
+          }
+          if (delta.id) (block as any).id = delta.id;
+
+          // Results
+          if (delta.result) (block as any).result = ((block as any).result || "") + delta.result;
+          if (delta.is_error !== undefined) (block as any).isError = delta.is_error;
+          if (delta.call_id) (block as any).callId = delta.call_id;
+          if (delta.url) (block as any).url = delta.url;
+          if (delta.query) (block as any).query = delta.query;
+          if (delta.server) (block as any).server = delta.server;
+          if (delta.tool) (block as any).tool = delta.tool;
+          if (delta.annotations) {
+            (block as any).annotations = (block as any).annotations || [];
+            (block as any).annotations.push(...delta.annotations);
+          }
         }
       }
       result.steps[index] = step;

--- a/tests/agents/filtering.test.ts
+++ b/tests/agents/filtering.test.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+describe("agents create inlining integration", () => {
+  const agentName = `test-filter-agent-${Date.now()}`;
+
+  beforeAll(() => {
+    // 1. Initialize agent
+    const initCmd = `bun run src/cli.ts agents init ${agentName} --base-agent antigravity-preview-05-2026`;
+    execSync(initCmd, { encoding: "utf-8" });
+
+    // 2. Add some extra files that should be ignored
+    fs.writeFileSync(path.join(agentName, "ignored_at_root.txt"), "ignore me");
+    fs.mkdirSync(path.join(agentName, "ignored_dir"), { recursive: true });
+    fs.writeFileSync(path.join(agentName, "ignored_dir", "file.txt"), "ignore me too");
+
+    // 3. Add some allowed files
+    fs.writeFileSync(path.join(agentName, "workspace", "allowed.txt"), "keep me");
+    fs.mkdirSync(path.join(agentName, "skills", "sub"), { recursive: true });
+    fs.writeFileSync(path.join(agentName, "skills", "sub", "allowed_skill.js"), "keep me too");
+  });
+
+  afterAll(() => {
+    fs.rmSync(agentName, { recursive: true, force: true });
+  });
+
+  test("should only include allowed files in dry-run curl output", () => {
+    const createCmd = `bun run src/cli.ts agents create --path ./${agentName} --dry-run`;
+    const stdout = execSync(createCmd, { encoding: "utf-8" });
+
+    const startIndex = stdout.indexOf("{");
+    const endIndex = stdout.lastIndexOf("}");
+    expect(startIndex).not.toBe(-1);
+    expect(endIndex).not.toBe(-1);
+
+    const rawBodyStr = stdout.substring(startIndex, endIndex + 1);
+
+    // Revert bash escaping of single quotes: '\'' -> '
+    // In the raw string, this is represented as '\n  ... agent'\\''s ...'
+    // We need to replace matches of: ' (single quote) followed by \' (escaped quote in JS, which is \\' in regex) followed by '
+    // Actually, printCurl did: replace(/'/g, "'\\''")
+    // So we just need to replace "'\\''" with "'"
+    const bodyStr = rawBodyStr.replace(/'\\''/g, "'");
+
+    const body = JSON.parse(bodyStr);
+
+    expect(body.base_environment).toBeDefined();
+    expect(body.base_environment.type).toBe("remote");
+    expect(body.base_environment.sources).toBeDefined();
+
+    const sources = body.base_environment.sources;
+    const targets = sources.map((s: any) => s.target);
+    console.log("Inlined targets in dry-run:", targets);
+
+    // Allowed
+    expect(targets).toContain("/credentials/.env");
+    expect(targets).toContain("/.agents/AGENTS.md");
+    expect(targets).toContain("/.agents/workspace/allowed.txt");
+    expect(targets).toContain("/.agents/skills/sub/allowed_skill.js");
+
+    // Ignored
+    expect(targets).not.toContain("/.agents/agent.yaml");
+    expect(targets).not.toContain("/.agents/ignored_at_root.txt");
+    expect(targets).not.toContain("/.agents/ignored_dir/file.txt");
+
+    // Total expected sources is 4
+    expect(sources.length).toBe(4);
+  });
+});

--- a/tests/agents/streaming_validation.test.ts
+++ b/tests/agents/streaming_validation.test.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+
+describe("gemini-api agents test streaming validation", () => {
+  test("validates that step.delta is not printed", async () => {
+    // Start a mock server
+    const server = Bun.serve({
+      port: 0, // random port
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/interactions") {
+          // Return SSE stream
+          const stream = new ReadableStream({
+            start(controller) {
+              const encoder = new TextEncoder();
+              const sendEvent = (data: object) => {
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+              };
+
+              sendEvent({ event_type: "interaction.created", interaction: { id: "test-id", status: "in_progress" } });
+              sendEvent({ event_type: "step.start", index: 0, step: { type: "thought", status: "in_progress" } });
+              sendEvent({ event_type: "step.delta", index: 0, delta: { text: "Thinking delta" } });
+              sendEvent({ event_type: "step.stop", index: 0, step: { type: "thought", status: "completed" } });
+              sendEvent({ event_type: "content.start", index: 1, content: { type: "text" } });
+              sendEvent({ event_type: "content.delta", index: 1, delta: { text: "Content delta" } });
+              sendEvent({ event_type: "content.stop", index: 1 });
+              sendEvent({ event_type: "interaction.completed", interaction: { id: "test-id", status: "completed" } });
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+              controller.close();
+            },
+          });
+
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              "Connection": "keep-alive",
+            },
+          });
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+
+    const baseUrl = `http://localhost:${server.port}`;
+
+    const child = spawn("bun", ["run", "src/cli.ts", "agents", "test", "--prompt", "Hello", "--path", "./tests/fixtures/agent-configs/valid"], {
+      env: { ...process.env, GEMINI_API_BASE_URL: baseUrl, GEMINI_API_KEY: "test-key" },
+    });
+
+    let output = "";
+    child.stdout.on("data", (data) => {
+      output += data.toString();
+    });
+
+    child.stderr.on("data", (data) => {
+      console.error("CLI stderr:", data.toString());
+    });
+
+    const exitCode = await new Promise((resolve) => {
+      child.on("close", resolve);
+    });
+
+    console.log("CLI Output:", output);
+    console.log("Exit Code:", exitCode);
+
+    server.stop();
+
+    // Verify that "Content delta" is present
+    expect(output).toContain("Content delta");
+    
+    // Verify that "Thinking delta" is NOT present (this confirms the bug)
+    expect(output).not.toContain("Thinking delta");
+  }, 30000);
+});

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -78,6 +78,111 @@ describe("buildInteractionRequest", () => {
     });
     expect(body.environment.config).toBeUndefined();
   });
+
+  test("github type source is normalized to repository", () => {
+    const body = buildInteractionRequest({
+      input: "Hello",
+      sources: [{ type: "github", source: "https://github.com/foo/bar", target: "/app" }],
+    }) as any;
+    expect(body.environment).toEqual({
+      type: "remote",
+      sources: [{ type: "repository", source: "https://github.com/foo/bar", target: "/app" }],
+    });
+  });
+
+  test("repository type source is parsed correctly", () => {
+    const body = buildInteractionRequest({
+      input: "Hello",
+      sources: [{ type: "repository", source: "https://github.com/foo/bar", target: "/app" }],
+    }) as any;
+    expect(body.environment).toEqual({
+      type: "remote",
+      sources: [{ type: "repository", source: "https://github.com/foo/bar", target: "/app" }],
+    });
+  });
+
+  test("direct environment mapping for strings", () => {
+    const bodyRemote = buildInteractionRequest({
+      input: "Hello",
+      environment: "remote",
+    }) as any;
+    expect(bodyRemote.environment).toBe("remote");
+
+    const bodyEnv = buildInteractionRequest({
+      input: "Hello",
+      environment: "env_xyz123",
+    }) as any;
+    expect(bodyEnv.environment).toBe("env_xyz123");
+  });
+
+  test("network configuration is preserved and sources normalized in object environments", () => {
+    const body = buildInteractionRequest({
+      input: "Hello",
+      environment: {
+        type: "remote",
+        sources: [{ type: "github", source: "https://github.com/foo/bar", target: "/app" }],
+        network: "disabled",
+      },
+    }) as any;
+    expect(body.environment).toEqual({
+      type: "remote",
+      sources: [{ type: "repository", source: "https://github.com/foo/bar", target: "/app" }],
+      network: "disabled",
+    });
+  });
+
+  test("outbound network config with allowlist", () => {
+    const body = buildInteractionRequest({
+      input: "Hello",
+      environment: {
+        type: "remote",
+        network: {
+          allowlist: [{ domain: "api.github.com" }],
+        },
+      },
+    }) as any;
+    expect(body.environment.network).toEqual({
+      allowlist: [{ domain: "api.github.com" }],
+    });
+  });
+
+  test("outbound network config with allowlist and transform rules", () => {
+    const body = buildInteractionRequest({
+      input: "Hello",
+      environment: {
+        type: "remote",
+        network: {
+          allowlist: [
+            {
+              domain: "api.github.com",
+              transform: {
+                "X-Forwarded-For": "1.2.3.4",
+              },
+            },
+          ],
+        },
+      },
+    }) as any;
+    expect(body.environment.network).toEqual({
+      allowlist: [
+        {
+          domain: "api.github.com",
+          transform: {
+            "X-Forwarded-For": "1.2.3.4",
+          },
+        },
+      ],
+    });
+  });
+
+  test("throws error when custom source target is '/'", () => {
+    expect(() => {
+      buildInteractionRequest({
+        input: "Hello",
+        sources: [{ type: "gcs", source: "gs://bucket/path", target: "/" }],
+      });
+    }).toThrow('Invalid source target: "/". Custom sources cannot be mounted at root.');
+  });
 });
 
 describe("Api-Revision header", () => {

--- a/tests/collect_files.test.ts
+++ b/tests/collect_files.test.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { collectInlineFiles } from "../src/lib/files";
+
+describe("collectInlineFiles filtering", () => {
+  const testDir = path.join(__dirname, "tmp-test-agent");
+
+  beforeAll(() => {
+    // Setup test directory structure
+    fs.mkdirSync(testDir, { recursive: true });
+    fs.mkdirSync(path.join(testDir, "workspace"), { recursive: true });
+    fs.mkdirSync(path.join(testDir, "skills"), { recursive: true });
+    fs.mkdirSync(path.join(testDir, "ignored_dir"), { recursive: true });
+
+    // Allowed files
+    fs.writeFileSync(path.join(testDir, "AGENTS.md"), "agents content");
+    fs.writeFileSync(path.join(testDir, ".env"), "KEY=VALUE");
+    fs.writeFileSync(path.join(testDir, "workspace", "file1.txt"), "file1 content");
+    fs.writeFileSync(path.join(testDir, "skills", "skill1.js"), "skill1 content");
+
+    // Ignored files
+    fs.writeFileSync(path.join(testDir, "agent.yaml"), "agent config");
+    fs.writeFileSync(path.join(testDir, "ignored_file.txt"), "ignored file");
+    fs.writeFileSync(path.join(testDir, "ignored_dir", "file2.txt"), "ignored dir file");
+    fs.writeFileSync(path.join(testDir, "package.json"), "{}");
+  });
+
+  afterAll(() => {
+    // Cleanup
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("should only collect allowed files", async () => {
+    const files = await collectInlineFiles(testDir);
+
+    const targets = files.map((f) => f.target);
+    console.log("Collected targets:", targets);
+
+    expect(targets).toContain("/credentials/.env");
+    expect(targets).toContain("/.agents/AGENTS.md");
+    expect(targets).toContain("/.agents/workspace/file1.txt");
+    expect(targets).toContain("/.agents/skills/skill1.js");
+
+    // Should NOT contain ignored files
+    expect(targets).not.toContain("/.agents/agent.yaml");
+    expect(targets).not.toContain("/.agents/ignored_file.txt");
+    expect(targets).not.toContain("/.agents/ignored_dir/file2.txt");
+    expect(targets).not.toContain("/.agents/package.json");
+
+    // Total expected allowed files is 4
+    expect(files.length).toBe(4);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -44,13 +44,13 @@ describe("AgentConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  test("valid base_environment with config sources", () => {
+  test("valid base_environment with remote sources and network", () => {
     const result = AgentConfigSchema.safeParse({
       id: "my-agent",
       base_environment: {
-        config: {
-          sources: [{ type: "gcs", source: "gs://bucket/path", target: "/target" }],
-        },
+        type: "remote",
+        sources: [{ type: "gcs", source: "gs://bucket/path", target: "/target" }],
+        network: { allowlist: [{ domain: "example.com" }] },
       },
     });
     expect(result.success).toBe(true);
@@ -87,7 +87,7 @@ describe("AgentConfigSchema", () => {
   test("valid config with examples", () => {
     const result = AgentConfigSchema.safeParse({
       id: "my-agent",
-      base_agent: "waverunner",
+      base_agent: "antigravity-preview-05-2026",
       examples: [
         { title: "Write a poem", prompt: "Write a short poem about coding" },
         { title: "Explain AI", prompt: "Explain artificial intelligence" },

--- a/tests/fixtures/agent-configs/with-examples/agent.yaml
+++ b/tests/fixtures/agent-configs/with-examples/agent.yaml
@@ -1,5 +1,5 @@
 id: test-agent-examples
-base_agent: waverunner
+base_agent: antigravity-preview-05-2026
 description: Agent with examples
 examples:
   - title: "Write a poem"

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -131,6 +131,7 @@ describe("dry-run", () => {
   });
 
   test("agents create --dry-run prints curl", () => {
+    fs.rmSync("dry-run-test", { recursive: true, force: true });
     execSync("source ~/.bash_profile && bun run src/cli.ts agents init dry-run-test", {
       encoding: "utf-8",
       shell: "/bin/bash",


### PR DESCRIPTION
## Summary

Three areas of improvement to the CLI:

### Network Configuration
- New `--network` and `--network-allowlist` flags on `run` command
- `NetworkConfigSchema` supporting `"disabled"` or `{ allowlist: [{ domain, transform? }] }`
- `"repository"` source type (normalizes `"github"` → `"repository"` automatically)
- Source target validation (rejects `/` mount point)
- Simplified `EnvironmentSchema`: `string | RemoteEnvironment` (removed legacy `{ enabled: true }`, `{ env_id }`, `{ config }` formats)

### Streaming Improvements
- Migrated renderer from `content.*` to `step.*` event model
- New `HumanStreamRenderer` API: `handleStepStart/Delta/Stop` with proper step lifecycle tracking
- Function calls accumulate args during deltas and render a clean one-liner on `step.stop`
- Special-case `write_file` to hide large content payloads
- Extracted shared `mapContentToStepEvent()` and `renderStepEvent()` helpers (DRY across `run.ts` and `test.ts`)
- `stream.ts`: auto-create content blocks from `step.delta` events for all content types

### File Inlining Restrictions
- Only inline `AGENTS.md` and `.env` from root directory
- Only traverse `workspace/` and `skills/` subdirectories
- All other root-level files and directories are silently ignored
- Updated DOCS.md and skill references to document this behavior

### Other
- `agents list` now uses `pageSize=100`
- Default environment changed from `{ enabled: true }` to `"remote"`

## Tests

- **43 targeted tests pass, 0 failures**
- New `tests/collect_files.test.ts` — unit test for file filtering
- New `tests/agents/filtering.test.ts` — integration test with `--dry-run` curl parsing
- New `tests/agents/streaming_validation.test.ts` — mock SSE server validates thought suppression
- 7 new test cases in `api.test.ts` for network/source/environment configs
- Fixed mock event type names (`interaction.created`/`completed`)
- Updated config test for new schema (removed legacy `{ config }` format)
